### PR TITLE
Fix restore.sh for privileged containers

### DIFF
--- a/Scripts/privileged/restore.sh
+++ b/Scripts/privileged/restore.sh
@@ -16,6 +16,6 @@
 # limitations under the License.
 ###############################################################################
 
-criu restore -D ./checkpointData --shell-job -v4 --log-file=restore.log --skip-file-rwx-check
+criu restore -D ./checkpointData --shell-job -v4 --log-file=restore.log
 
 exit 0


### PR DESCRIPTION
--skip-file-rwx-check does not yet exist in a CRIU release. Since the privileged containers don't build CRIU from source and instead rely on the distro's CRIU package, this option should be removed from the restore.sh script.

Signed-off-by: Irwin D'Souza <dsouzai.gh@gmail.com>